### PR TITLE
Nissix plugin scope-packages on draft-js-anchor-plugin

### DIFF
--- a/draft-js-anchor-plugin/package.json
+++ b/draft-js-anchor-plugin/package.json
@@ -40,7 +40,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-anchor-plugin/src/utils/EditorUtils.js
+++ b/draft-js-anchor-plugin/src/utils/EditorUtils.js
@@ -1,4 +1,4 @@
-import { RichUtils, EditorState } from 'draft-js';
+import { RichUtils, EditorState } from '@wix/draft-js';
 
 export default {
   createLinkAtSelection(editorState, url) {

--- a/draft-js-anchor-plugin/yarn.lock
+++ b/draft-js-anchor-plugin/yarn.lock
@@ -14,6 +14,11 @@ decorate-component-with-props@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/decorate-component-with-props/-/decorate-component-with-props-1.0.2.tgz#5764d3cf6a58685a522201bad31bff0cb531e5fe"
 
+draft-js-plugins-utils@2.0.2:
+  version "2.0.2"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/draft-js-plugins-utils/-/draft-js-plugins-utils-2.0.2.tgz#b2f8572808a2b921e079ff44d03ac7e74fb2c598"
+  integrity sha1-svhXKAiiuSHgef9E0DrH50+yxZg=
+
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
@@ -35,14 +40,6 @@ fbjs@^0.8.9:
 iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
-
-immutable@~3.7.4:
-  version "3.7.6"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
-
-ip-regex@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
 
 is-stream@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.458s
warning " > decorate-component-with-props@1.0.2" has unmet peer dependency "react@^0.14.0 || ^15.0.0-rc".
warning " > draft-js-plugins-utils@2.0.2" has unmet peer dependency "draft-js@^0.10.1".



Output Log:
Migrating package "draft-js-anchor-plugin" in draft-js-anchor-plugin


## Migration from non scope to @wix/scoped packages
> /tmp/d10a94c0ff7b984526248e54e655043d/draft-js-anchor-plugin

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/utils/EditorUtils.js
```
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 1.59s.

