### PR TITLE
Nissix plugin scope-packages on draft-js-plugins

### DIFF
--- a/docs/client/components/pages/Alignment/SimpleAlignmentEditor/index.js
+++ b/docs/client/components/pages/Alignment/SimpleAlignmentEditor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   convertFromRaw,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 

--- a/docs/client/components/pages/Alignment/ThemedAlignmentEditor/index.js
+++ b/docs/client/components/pages/Alignment/ThemedAlignmentEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { convertFromRaw, EditorState } from 'draft-js';
+import { convertFromRaw, EditorState } from '@wix/draft-js';
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 import createAlignmentPlugin from 'draft-js-alignment-plugin';
 import createFocusPlugin from 'draft-js-focus-plugin';

--- a/docs/client/components/pages/Divider/DividerWithSideToolbarEditor/index.js
+++ b/docs/client/components/pages/Divider/DividerWithSideToolbarEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { convertFromRaw, EditorState } from 'draft-js';
+import { convertFromRaw, EditorState } from '@wix/draft-js';
 
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 import createFocusPlugin from 'draft-js-focus-plugin';

--- a/docs/client/components/pages/DragNDrop/CustomImageEditor/index.js
+++ b/docs/client/components/pages/DragNDrop/CustomImageEditor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   convertFromRaw,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 

--- a/docs/client/components/pages/Focus/SimpleFocusEditor/index.js
+++ b/docs/client/components/pages/Focus/SimpleFocusEditor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   convertFromRaw,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 

--- a/docs/client/components/pages/Home/UnicornEditor/index.js
+++ b/docs/client/components/pages/Home/UnicornEditor/index.js
@@ -14,7 +14,7 @@ import createImagePlugin from 'draft-js-image-plugin';
 import createFocusPlugin from 'draft-js-focus-plugin';
 import createAlignmentPlugin from 'draft-js-alignment-plugin';
 import createBlockDndPlugin from 'draft-js-drag-n-drop-plugin';
-import { convertFromRaw, EditorState } from 'draft-js';
+import { convertFromRaw, EditorState } from '@wix/draft-js';
 import styles from './styles.css';
 import stickers from './stickers';
 import mentions from './mentions';

--- a/docs/client/components/pages/Image/CustomImageEditor/index.js
+++ b/docs/client/components/pages/Image/CustomImageEditor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   convertFromRaw,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 

--- a/docs/client/components/pages/Image/SimpleImageEditor/index.js
+++ b/docs/client/components/pages/Image/SimpleImageEditor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   convertFromRaw,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 import Editor from 'draft-js-plugins-editor';
 

--- a/docs/client/components/pages/Linkify/CustomComponentLinkifyEditor/index.js
+++ b/docs/client/components/pages/Linkify/CustomComponentLinkifyEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createLinkifyPlugin from 'draft-js-linkify-plugin';
 import editorStyles from './editorStyles.css';

--- a/docs/client/components/pages/Linkify/CustomLinkifyEditor/index.js
+++ b/docs/client/components/pages/Linkify/CustomLinkifyEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createLinkifyPlugin from 'draft-js-linkify-plugin';
 import editorStyles from './editorStyles.css';

--- a/docs/client/components/pages/Linkify/SimpleLinkifyEditor/index.js
+++ b/docs/client/components/pages/Linkify/SimpleLinkifyEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createLinkifyPlugin from 'draft-js-linkify-plugin';
 import editorStyles from './editorStyles.css';

--- a/docs/client/components/pages/Mention/CustomComponentMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/CustomComponentMentionEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createMentionPlugin, { defaultSuggestionsFilter } from 'draft-js-mention-plugin';
 import editorStyles from './editorStyles.css';

--- a/docs/client/components/pages/Mention/CustomMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/CustomMentionEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createMentionPlugin, { defaultSuggestionsFilter } from 'draft-js-mention-plugin';
 import editorStyles from './editorStyles.css';

--- a/docs/client/components/pages/Mention/RemoteMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/RemoteMentionEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 
 import Editor from 'draft-js-plugins-editor';
 

--- a/docs/client/components/pages/Mention/SimpleMentionEditor/index.js
+++ b/docs/client/components/pages/Mention/SimpleMentionEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createMentionPlugin, { defaultSuggestionsFilter } from 'draft-js-mention-plugin';
 import editorStyles from './editorStyles.css';

--- a/docs/client/components/pages/Playground/PlaygroundEditor/index.js
+++ b/docs/client/components/pages/Playground/PlaygroundEditor/index.js
@@ -3,7 +3,7 @@ import {
   EditorState,
   Modifier,
   RichUtils,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 import Editor, { createEditorStateWithText } from 'draft-js-plugins-editor';
 

--- a/docs/client/components/pages/Resizeable/SimpleResizeableEditor/index.js
+++ b/docs/client/components/pages/Resizeable/SimpleResizeableEditor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   convertFromRaw,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 

--- a/docs/client/components/pages/Sticker/CustomStickerEditor/index.js
+++ b/docs/client/components/pages/Sticker/CustomStickerEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createStickerPlugin from 'draft-js-sticker-plugin';
 import editorStyles from './editorStyles.css';

--- a/docs/client/components/pages/Sticker/SimpleStickerEditor/index.js
+++ b/docs/client/components/pages/Sticker/SimpleStickerEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createStickerPlugin from 'draft-js-sticker-plugin';
 import editorStyles from './editorStyles.css';

--- a/docs/client/components/pages/Undo/CustomUndoEditor/index.js
+++ b/docs/client/components/pages/Undo/CustomUndoEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createUndoPlugin from 'draft-js-undo-plugin';
 import editorStyles from './editorStyles.css';

--- a/docs/client/components/pages/Undo/SimpleUndoEditor/index.js
+++ b/docs/client/components/pages/Undo/SimpleUndoEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createUndoPlugin from 'draft-js-undo-plugin';
 import editorStyles from './editorStyles.css';

--- a/docs/client/components/pages/Video/CustomAddVideoVideoEditor/index.js
+++ b/docs/client/components/pages/Video/CustomAddVideoVideoEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createVideoPlugin from 'draft-js-video-plugin';
 import VideoAdd from './VideoAdd';

--- a/docs/client/components/pages/Video/CustomVideoEditor/index.js
+++ b/docs/client/components/pages/Video/CustomVideoEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState, convertFromRaw } from 'draft-js';
+import { EditorState, convertFromRaw } from '@wix/draft-js';
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 
 import createAlignmentPlugin from 'draft-js-alignment-plugin';

--- a/docs/client/components/pages/Video/SimpleVideoEditor/index.js
+++ b/docs/client/components/pages/Video/SimpleVideoEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState, convertFromRaw } from 'draft-js';
+import { EditorState, convertFromRaw } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createVideoPlugin from 'draft-js-video-plugin';
 import editorStyles from './editorStyles.css';

--- a/draft-js-alignment-plugin/package.json
+++ b/draft-js-alignment-plugin/package.json
@@ -38,7 +38,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-alignment-plugin/src/index.js
+++ b/draft-js-alignment-plugin/src/index.js
@@ -1,4 +1,4 @@
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import decorateComponentWithProps from 'decorate-component-with-props';
 import createDecorator from './createDecorator';
 import AlignmentTool from './AlignmentTool';

--- a/draft-js-anchor-plugin/package.json
+++ b/draft-js-anchor-plugin/package.json
@@ -40,7 +40,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-anchor-plugin/src/utils/EditorUtils.js
+++ b/draft-js-anchor-plugin/src/utils/EditorUtils.js
@@ -1,4 +1,4 @@
-import { RichUtils, EditorState } from 'draft-js';
+import { RichUtils, EditorState } from '@wix/draft-js';
 
 export default {
   createLinkAtSelection(editorState, url) {

--- a/draft-js-buttons/package.json
+++ b/draft-js-buttons/package.json
@@ -30,7 +30,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-buttons/src/utils/createBlockStyleButton.js
+++ b/draft-js-buttons/src/utils/createBlockStyleButton.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-children-prop */
 import React, { Component } from 'react';
-import { RichUtils } from 'draft-js';
+import { RichUtils } from '@wix/draft-js';
 import unionClassNames from 'union-class-names';
 
 export default ({ blockType, children }) => (

--- a/draft-js-buttons/src/utils/createInlineStyleButton.js
+++ b/draft-js-buttons/src/utils/createInlineStyleButton.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-children-prop */
 import React, { Component } from 'react';
-import { RichUtils } from 'draft-js';
+import { RichUtils } from '@wix/draft-js';
 import unionClassNames from 'union-class-names';
 
 export default ({ style, children }) => (

--- a/draft-js-counter-plugin/package.json
+++ b/draft-js-counter-plugin/package.json
@@ -38,7 +38,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-counter-plugin/src/CharCounter/__test__/index.js
+++ b/draft-js-counter-plugin/src/CharCounter/__test__/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
-import { EditorState, ContentState } from 'draft-js';
+import { EditorState, ContentState } from '@wix/draft-js';
 import createCounterPlugin from '../../index';
 
 describe('CounterPlugin Character Counter', () => {

--- a/draft-js-counter-plugin/src/CustomCounter/__test__/index.js
+++ b/draft-js-counter-plugin/src/CustomCounter/__test__/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
-import { EditorState, ContentState } from 'draft-js';
+import { EditorState, ContentState } from '@wix/draft-js';
 import createCounterPlugin from '../../index';
 
 describe('CounterPlugin Line Counter', () => {

--- a/draft-js-counter-plugin/src/LineCounter/__test__/index.js
+++ b/draft-js-counter-plugin/src/LineCounter/__test__/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
-import { EditorState, ContentState } from 'draft-js';
+import { EditorState, ContentState } from '@wix/draft-js';
 import createCounterPlugin from '../../index';
 
 describe('CounterPlugin Line Counter', () => {

--- a/draft-js-counter-plugin/src/WordCounter/__test__/index.js
+++ b/draft-js-counter-plugin/src/WordCounter/__test__/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
-import { EditorState, ContentState } from 'draft-js';
+import { EditorState, ContentState } from '@wix/draft-js';
 import createCounterPlugin from '../../index';
 
 describe('CounterPlugin Word Counter', () => {

--- a/draft-js-divider-plugin/package.json
+++ b/draft-js-divider-plugin/package.json
@@ -25,10 +25,8 @@
   "scripts": {
     "clean": "../node_modules/.bin/rimraf lib",
     "build": "npm run clean && npm run build:js && npm run build:css",
-    "build:js":
-      "WEBPACK_CONFIG=$(pwd)/webpack.config.js BABEL_DISABLE_CACHE=1 BABEL_ENV=production NODE_ENV=production ../node_modules/.bin/babel --out-dir='lib' --ignore='__test__/*' src",
-    "build:css":
-      "node ../scripts/concatCssFiles $(pwd) && ../node_modules/.bin/rimraf lib-css",
+    "build:js": "WEBPACK_CONFIG=$(pwd)/webpack.config.js BABEL_DISABLE_CACHE=1 BABEL_ENV=production NODE_ENV=production ../node_modules/.bin/babel --out-dir='lib' --ignore='__test__/*' src",
+    "build:css": "node ../scripts/concatCssFiles $(pwd) && ../node_modules/.bin/rimraf lib-css",
     "prepublish": "npm run build"
   },
   "license": "MIT",
@@ -38,7 +36,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-divider-plugin/src/modifiers/addDivider.js
+++ b/draft-js-divider-plugin/src/modifiers/addDivider.js
@@ -1,4 +1,4 @@
-import { EditorState, AtomicBlockUtils } from 'draft-js';
+import { EditorState, AtomicBlockUtils } from '@wix/draft-js';
 
 export default (entityType) => (editorState, data) => {
   const contentState = editorState.getCurrentContent();

--- a/draft-js-drag-n-drop-plugin/package.json
+++ b/draft-js-drag-n-drop-plugin/package.json
@@ -36,7 +36,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-drag-n-drop-plugin/src/handleDrop.js
+++ b/draft-js-drag-n-drop-plugin/src/handleDrop.js
@@ -1,4 +1,4 @@
-import { EditorState, SelectionState } from 'draft-js';
+import { EditorState, SelectionState } from '@wix/draft-js';
 import addBlock from './modifiers/addBlock';
 import removeBlock from './modifiers/removeBlock';
 import { DRAFTJS_BLOCK_KEY } from './constants';

--- a/draft-js-drag-n-drop-plugin/src/modifiers/addBlock.js
+++ b/draft-js-drag-n-drop-plugin/src/modifiers/addBlock.js
@@ -5,7 +5,7 @@ import {
   BlockMapBuilder,
   ContentBlock,
   genKey
-} from 'draft-js';
+} from '@wix/draft-js';
 
 export default function (editorState, selection, type, data, entityType, text = ' ') {
   const currentContentState = editorState.getCurrentContent();

--- a/draft-js-drag-n-drop-plugin/src/modifiers/removeBlock.js
+++ b/draft-js-drag-n-drop-plugin/src/modifiers/removeBlock.js
@@ -1,4 +1,4 @@
-import { Modifier, SelectionState } from 'draft-js';
+import { Modifier, SelectionState } from '@wix/draft-js';
 
 export default function (contentState, blockKey) {
   const afterKey = contentState.getKeyAfter(blockKey);

--- a/draft-js-drag-n-drop-upload-plugin/package.json
+++ b/draft-js-drag-n-drop-upload-plugin/package.json
@@ -36,7 +36,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-drag-n-drop-upload-plugin/src/handleDroppedFiles.js
+++ b/draft-js-drag-n-drop-upload-plugin/src/handleDroppedFiles.js
@@ -1,6 +1,6 @@
 // import replaceBlock from './modifiers/replaceBlock';
 // import modifyBlockData from './modifiers/modifyBlockData';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import { readFiles } from './utils/file';
 // import { getBlocksWhereEntityData } from './utils/block';
 

--- a/draft-js-drag-n-drop-upload-plugin/src/modifiers/modifyBlockData.js
+++ b/draft-js-drag-n-drop-upload-plugin/src/modifiers/modifyBlockData.js
@@ -1,4 +1,4 @@
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 
 export default function (editorState, key, data) {
   const currentContentState = editorState.getCurrentContent();

--- a/draft-js-drag-n-drop-upload-plugin/src/modifiers/replaceBlock.js
+++ b/draft-js-drag-n-drop-upload-plugin/src/modifiers/replaceBlock.js
@@ -1,4 +1,4 @@
-import { Modifier, EditorState, SelectionState } from 'draft-js';
+import { Modifier, EditorState, SelectionState } from '@wix/draft-js';
 
 export default function (editorState, blockKey, newType) {
   let content = editorState.getCurrentContent();

--- a/draft-js-emoji-plugin/package.json
+++ b/draft-js-emoji-plugin/package.json
@@ -57,7 +57,7 @@
     "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-stage-0": "^6.22.0",
     "css-loader": "^0.26.2",
-    "draft-js": "^0.10.5",
+    "@wix/draft-js": "^0.10.5",
     "extract-text-webpack-plugin": "^2.0.0",
     "postcss-loader": "^1.3.3",
     "react": "^15.5.4",
@@ -68,7 +68,7 @@
     "webpack-hot-middleware": "^2.17.1"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   },

--- a/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
+++ b/draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { genKey } from 'draft-js';
+import { genKey } from '@wix/draft-js';
 import Entry from './Entry';
 import addEmoji, { Mode as AddEmojiMode } from '../../modifiers/addEmoji';
 import getSearchText from '../../utils/getSearchText';

--- a/draft-js-emoji-plugin/src/index.js
+++ b/draft-js-emoji-plugin/src/index.js
@@ -2,7 +2,7 @@ import { Map, List } from 'immutable';
 
 import keys from 'lodash.keys';
 import decorateComponentWithProps from 'decorate-component-with-props';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Emoji from './components/Emoji';
 import EmojiSuggestions from './components/EmojiSuggestions';
 import EmojiSuggestionsPortal from './components/EmojiSuggestionsPortal';

--- a/draft-js-emoji-plugin/src/modifiers/addEmoji.js
+++ b/draft-js-emoji-plugin/src/modifiers/addEmoji.js
@@ -1,4 +1,4 @@
-import { Modifier, EditorState } from 'draft-js';
+import { Modifier, EditorState } from '@wix/draft-js';
 import getSearchText from '../utils/getSearchText';
 import emojiList from '../utils/emojiList';
 import convertShortNameToUnicode from '../utils/convertShortNameToUnicode';

--- a/draft-js-emoji-plugin/src/modifiers/attachImmutableEntitiesToEmojis.js
+++ b/draft-js-emoji-plugin/src/modifiers/attachImmutableEntitiesToEmojis.js
@@ -1,4 +1,4 @@
-import { EditorState, Modifier, SelectionState } from 'draft-js';
+import { EditorState, Modifier, SelectionState } from '@wix/draft-js';
 import findWithRegex from 'find-with-regex';
 import emojione from 'emojione';
 

--- a/draft-js-focus-plugin/package.json
+++ b/draft-js-focus-plugin/package.json
@@ -37,7 +37,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-focus-plugin/src/index.js
+++ b/draft-js-focus-plugin/src/index.js
@@ -1,4 +1,4 @@
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import insertNewLine from './modifiers/insertNewLine';
 import setSelection from './modifiers/setSelection';
 import setSelectionToBlock from './modifiers/setSelectionToBlock';

--- a/draft-js-focus-plugin/src/modifiers/insertNewLine.js
+++ b/draft-js-focus-plugin/src/modifiers/insertNewLine.js
@@ -4,7 +4,7 @@ import {
   EditorState,
   BlockMapBuilder,
   genKey as generateRandomKey,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 const insertBlockAfterSelection = (contentState, selectionState, newBlock) => {
   const targetKey = selectionState.getStartKey();

--- a/draft-js-focus-plugin/src/modifiers/removeBlock.js
+++ b/draft-js-focus-plugin/src/modifiers/removeBlock.js
@@ -1,4 +1,4 @@
-import { Modifier, EditorState, SelectionState } from 'draft-js';
+import { Modifier, EditorState, SelectionState } from '@wix/draft-js';
 
 /* NOT USED at the moment, but might be valuable if we want to fix atomic block behaviour */
 

--- a/draft-js-focus-plugin/src/modifiers/setSelection.js
+++ b/draft-js-focus-plugin/src/modifiers/setSelection.js
@@ -1,5 +1,5 @@
-import { SelectionState, EditorState } from 'draft-js';
-import DraftOffsetKey from 'draft-js/lib/DraftOffsetKey';
+import { SelectionState, EditorState } from '@wix/draft-js';
+import DraftOffsetKey from '@wix/draft-js/lib/DraftOffsetKey';
 
 // Set selection of editor to next/previous block
 export default (getEditorState, setEditorState, mode, event) => {

--- a/draft-js-focus-plugin/src/modifiers/setSelectionToBlock.js
+++ b/draft-js-focus-plugin/src/modifiers/setSelectionToBlock.js
@@ -1,5 +1,5 @@
-import { SelectionState, EditorState } from 'draft-js';
-import DraftOffsetKey from 'draft-js/lib/DraftOffsetKey';
+import { SelectionState, EditorState } from '@wix/draft-js';
+import DraftOffsetKey from '@wix/draft-js/lib/DraftOffsetKey';
 
 // Set selection of editor to next/previous block
 export default (getEditorState, setEditorState, newActiveBlock) => {

--- a/draft-js-hashtag-plugin/package.json
+++ b/draft-js-hashtag-plugin/package.json
@@ -38,7 +38,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-image-plugin/package.json
+++ b/draft-js-image-plugin/package.json
@@ -37,7 +37,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-image-plugin/src/modifiers/addImage.js
+++ b/draft-js-image-plugin/src/modifiers/addImage.js
@@ -1,7 +1,7 @@
 import {
   EditorState,
   AtomicBlockUtils,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 export default (editorState, url, extraData) => {
   const urlType = 'IMAGE';

--- a/draft-js-inline-toolbar-plugin/package.json
+++ b/draft-js-inline-toolbar-plugin/package.json
@@ -38,7 +38,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
-import { getVisibleSelectionRect } from 'draft-js';
+import { getVisibleSelectionRect } from '@wix/draft-js';
 
 export default class Toolbar extends React.Component {
 

--- a/draft-js-linkify-plugin/package.json
+++ b/draft-js-linkify-plugin/package.json
@@ -39,7 +39,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-mention-plugin/package.json
+++ b/draft-js-mention-plugin/package.json
@@ -39,7 +39,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-mention-plugin/src/Mention/__test__/index.js
+++ b/draft-js-mention-plugin/src/Mention/__test__/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from 'enzyme';
 import { Map } from 'immutable';
-import { ContentState } from 'draft-js';
+import { ContentState } from '@wix/draft-js';
 import { expect } from 'chai';
 import Mention from '../index';
 

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { genKey } from 'draft-js';
+import { genKey } from '@wix/draft-js';
 import escapeRegExp from 'lodash.escaperegexp';
 import Entry from './Entry';
 import addMention from '../modifiers/addMention';

--- a/draft-js-mention-plugin/src/modifiers/addMention.js
+++ b/draft-js-mention-plugin/src/modifiers/addMention.js
@@ -1,4 +1,4 @@
-import { Modifier, EditorState } from 'draft-js';
+import { Modifier, EditorState } from '@wix/draft-js';
 import getSearchText from '../utils/getSearchText';
 import getTypeByTrigger from '../utils/getTypeByTrigger';
 

--- a/draft-js-plugins-editor/package.json
+++ b/draft-js-plugins-editor/package.json
@@ -35,7 +35,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-plugins-editor/src/Editor/__test__/MultiDecorator.js
+++ b/draft-js-plugins-editor/src/Editor/__test__/MultiDecorator.js
@@ -1,4 +1,4 @@
-import Draft from 'draft-js';
+import Draft from '@wix/draft-js';
 import { expect } from 'chai';
 import MultiDecorator from '../MultiDecorator';
 

--- a/draft-js-plugins-editor/src/Editor/__test__/index.js
+++ b/draft-js-plugins-editor/src/Editor/__test__/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { mount, shallow } from 'enzyme';
 import { expect } from 'chai';
-import { EditorState, DefaultDraftBlockRenderMap, Editor } from 'draft-js';
+import { EditorState, DefaultDraftBlockRenderMap, Editor } from '@wix/draft-js';
 import { Map } from 'immutable';
 import sinon from 'sinon';
 import PluginEditor, { createEditorStateWithText } from '../../index';

--- a/draft-js-plugins-editor/src/Editor/createCompositeDecorator.js
+++ b/draft-js-plugins-editor/src/Editor/createCompositeDecorator.js
@@ -3,7 +3,7 @@
  */
 
 import { List } from 'immutable';
-import { CompositeDecorator } from 'draft-js';
+import { CompositeDecorator } from '@wix/draft-js';
 import decorateComponentWithProps from 'decorate-component-with-props';
 
 export default (decorators, getEditorState, setEditorState) => {

--- a/draft-js-plugins-editor/src/Editor/defaultKeyBindingPlugin.js
+++ b/draft-js-plugins-editor/src/Editor/defaultKeyBindingPlugin.js
@@ -1,4 +1,4 @@
-import { getDefaultKeyBinding } from 'draft-js';
+import { getDefaultKeyBinding } from '@wix/draft-js';
 
 /**
  * Handle default key bindings.

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -5,7 +5,7 @@ import {
   EditorState,
   Editor,
   DefaultDraftBlockRenderMap,
-} from 'draft-js';
+} from '@wix/draft-js';
 import { Map } from 'immutable';
 import proxies from './proxies';
 import moveSelectionToEnd from './moveSelectionToEnd';

--- a/draft-js-plugins-editor/src/Editor/moveSelectionToEnd.js
+++ b/draft-js-plugins-editor/src/Editor/moveSelectionToEnd.js
@@ -1,7 +1,7 @@
 import {
   EditorState,
   SelectionState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 /**
  * Returns a new EditorState where the Selection is at the end.

--- a/draft-js-plugins-editor/src/utils/createEditorStateWithText.js
+++ b/draft-js-plugins-editor/src/utils/createEditorStateWithText.js
@@ -5,7 +5,7 @@
 import {
   ContentState,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 export default (text) => EditorState.createWithContent(
   ContentState.createFromText(text)

--- a/draft-js-plugins-utils/package.json
+++ b/draft-js-plugins-utils/package.json
@@ -30,6 +30,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "draft-js": "^0.10.1"
+    "@wix/draft-js": "^0.10.1"
   }
 }

--- a/draft-js-plugins-utils/src/index.js
+++ b/draft-js-plugins-utils/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 
-import { RichUtils, EditorState } from 'draft-js';
-import type DraftEntityInstance from 'draft-js/lib/DraftEntityInstance';
+import { RichUtils, EditorState } from '@wix/draft-js';
+import type DraftEntityInstance from '@wix/draft-js/lib/DraftEntityInstance';
 
 export default {
   createLinkAtSelection(editorState: EditorState, url: string): EditorState {

--- a/draft-js-resizeable-plugin/package.json
+++ b/draft-js-resizeable-plugin/package.json
@@ -36,7 +36,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-resizeable-plugin/src/index.js
+++ b/draft-js-resizeable-plugin/src/index.js
@@ -1,4 +1,4 @@
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import createDecorator from './createDecorator';
 
 const store = {

--- a/draft-js-side-toolbar-plugin/package.json
+++ b/draft-js-side-toolbar-plugin/package.json
@@ -38,7 +38,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
-import DraftOffsetKey from 'draft-js/lib/DraftOffsetKey';
+import DraftOffsetKey from '@wix/draft-js/lib/DraftOffsetKey';
 
 export default class Toolbar extends React.Component {
 

--- a/draft-js-static-toolbar-plugin/package.json
+++ b/draft-js-static-toolbar-plugin/package.json
@@ -38,7 +38,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-sticker-plugin/package.json
+++ b/draft-js-sticker-plugin/package.json
@@ -38,7 +38,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-sticker-plugin/src/modifiers/addSticker.js
+++ b/draft-js-sticker-plugin/src/modifiers/addSticker.js
@@ -9,7 +9,7 @@ import {
   EditorState,
   genKey,
   Modifier,
-} from 'draft-js';
+} from '@wix/draft-js';
 import {
   List,
   Repeat

--- a/draft-js-sticker-plugin/src/modifiers/cleanupEmptyStickers.js
+++ b/draft-js-sticker-plugin/src/modifiers/cleanupEmptyStickers.js
@@ -6,7 +6,7 @@ import {
   EditorState,
   Modifier,
   SelectionState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 const cleanupSticker = (editorState: Object, blockKey: String) => {
   const content = editorState.getCurrentContent();

--- a/draft-js-sticker-plugin/src/modifiers/removeSticker.js
+++ b/draft-js-sticker-plugin/src/modifiers/removeSticker.js
@@ -6,7 +6,7 @@ import {
   EditorState,
   Modifier,
   SelectionState
-} from 'draft-js';
+} from '@wix/draft-js';
 
 export default (editorState: Object, blockKey: String) => {
   let content = editorState.getCurrentContent();

--- a/draft-js-undo-plugin/package.json
+++ b/draft-js-undo-plugin/package.json
@@ -37,7 +37,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-undo-plugin/src/RedoButton/__test__/index.js
+++ b/draft-js-undo-plugin/src/RedoButton/__test__/index.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
-import { EditorState, Modifier } from 'draft-js';
+import { EditorState, Modifier } from '@wix/draft-js';
 import Redo from '../index';
 
 chai.use(sinonChai);

--- a/draft-js-undo-plugin/src/RedoButton/index.js
+++ b/draft-js-undo-plugin/src/RedoButton/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import unionClassNames from 'union-class-names';
 
 class RedoButton extends Component {

--- a/draft-js-undo-plugin/src/UndoButton/__test__/index.js
+++ b/draft-js-undo-plugin/src/UndoButton/__test__/index.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
-import { EditorState, Modifier } from 'draft-js';
+import { EditorState, Modifier } from '@wix/draft-js';
 import Undo from '../index';
 
 chai.use(sinonChai);

--- a/draft-js-undo-plugin/src/UndoButton/index.js
+++ b/draft-js-undo-plugin/src/UndoButton/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import unionClassNames from 'union-class-names';
 
 class UndoButton extends Component {

--- a/draft-js-undo-plugin/src/__test__/index.js
+++ b/draft-js-undo-plugin/src/__test__/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import createUndoPlugin from '../index';
 
 describe('UndoPlugin Config', () => {

--- a/draft-js-video-plugin/package.json
+++ b/draft-js-video-plugin/package.json
@@ -35,7 +35,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-video-plugin/src/video/modifiers/addVideo.js
+++ b/draft-js-video-plugin/src/video/modifiers/addVideo.js
@@ -1,7 +1,7 @@
 import {
   AtomicBlockUtils,
   RichUtils,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 import * as types from '../constants';
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "license": "MIT",
   "dependencies": {
     "decorate-component-with-props": "^1.0.2",
-    "draft-js": "^0.10.5",
+    "@wix/draft-js": "^0.10.5",
     "emojione": "^2.2.7",
     "eslint-plugin-import": "^2.2.0",
     "find-with-regex": "^1.1.3",

--- a/stories/Alignment/SimpleAlignmentEditor/index.js
+++ b/stories/Alignment/SimpleAlignmentEditor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   convertFromRaw,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 import createAlignmentPlugin from 'draft-js-alignment-plugin';
 import createFocusPlugin from 'draft-js-focus-plugin';

--- a/stories/Alignment/ThemedAlignmentEditor/index.js
+++ b/stories/Alignment/ThemedAlignmentEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { convertFromRaw, EditorState } from 'draft-js';
+import { convertFromRaw, EditorState } from '@wix/draft-js';
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 import createAlignmentPlugin from 'draft-js-alignment-plugin';
 import createFocusPlugin from 'draft-js-focus-plugin';

--- a/stories/Divider/DividerWithSideToolbarEditor/index.js
+++ b/stories/Divider/DividerWithSideToolbarEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { convertFromRaw, EditorState } from 'draft-js';
+import { convertFromRaw, EditorState } from '@wix/draft-js';
 
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 import createFocusPlugin from 'draft-js-focus-plugin';

--- a/stories/DragNDrop/CustomImageEditor/index.js
+++ b/stories/DragNDrop/CustomImageEditor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   convertFromRaw,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 import createImagePlugin from 'draft-js-image-plugin';
 import createFocusPlugin from 'draft-js-focus-plugin';

--- a/stories/Focus/SimpleFocusEditor/index.js
+++ b/stories/Focus/SimpleFocusEditor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   convertFromRaw,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 import createFocusPlugin from 'draft-js-focus-plugin';
 import createColorBlockPlugin from './colorBlockPlugin';

--- a/stories/Home/UnicornEditor/index.js
+++ b/stories/Home/UnicornEditor/index.js
@@ -9,7 +9,7 @@ import createUndoPlugin from 'draft-js-undo-plugin';
 import {
   ContentState,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 import styles from './styles.css';
 import stickers from './stickers';
 import mentions from './mentions';

--- a/stories/Image/CustomImageEditor/index.js
+++ b/stories/Image/CustomImageEditor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   convertFromRaw,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 

--- a/stories/Image/SimpleImageEditor/index.js
+++ b/stories/Image/SimpleImageEditor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   convertFromRaw,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createImagePlugin from 'draft-js-image-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/Linkify/CustomComponentLinkifyEditor/index.js
+++ b/stories/Linkify/CustomComponentLinkifyEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createLinkifyPlugin from 'draft-js-linkify-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/Linkify/CustomLinkifyEditor/index.js
+++ b/stories/Linkify/CustomLinkifyEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createLinkifyPlugin from 'draft-js-linkify-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/Linkify/SimpleLinkifyEditor/index.js
+++ b/stories/Linkify/SimpleLinkifyEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState, ContentState } from 'draft-js';
+import { EditorState, ContentState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createLinkifyPlugin from 'draft-js-linkify-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/Mention/CustomComponentMentionEditor/index.js
+++ b/stories/Mention/CustomComponentMentionEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createMentionPlugin, { defaultSuggestionsFilter } from 'draft-js-mention-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/Mention/CustomMentionEditor/index.js
+++ b/stories/Mention/CustomMentionEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createMentionPlugin, { defaultSuggestionsFilter } from 'draft-js-mention-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/Mention/MentionEditorWithCustomTrigger/index.js
+++ b/stories/Mention/MentionEditorWithCustomTrigger/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState, ContentState } from 'draft-js';
+import { EditorState, ContentState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createMentionPlugin, { defaultSuggestionsFilter } from 'draft-js-mention-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/Mention/RemoteMentionEditor/index.js
+++ b/stories/Mention/RemoteMentionEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 
 import Editor from 'draft-js-plugins-editor';
 

--- a/stories/Mention/SimpleMentionEditor/index.js
+++ b/stories/Mention/SimpleMentionEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createMentionPlugin, { defaultSuggestionsFilter } from 'draft-js-mention-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/Resizeable/SimpleResizeableEditor/index.js
+++ b/stories/Resizeable/SimpleResizeableEditor/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import {
   convertFromRaw,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 

--- a/stories/Sticker/CustomStickerEditor/index.js
+++ b/stories/Sticker/CustomStickerEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createStickerPlugin from 'draft-js-sticker-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/Sticker/SimpleStickerEditor/index.js
+++ b/stories/Sticker/SimpleStickerEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createStickerPlugin from 'draft-js-sticker-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/Undo/CustomUndoEditor/index.js
+++ b/stories/Undo/CustomUndoEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createUndoPlugin from 'draft-js-undo-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/Undo/SimpleUndoEditor/index.js
+++ b/stories/Undo/SimpleUndoEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createUndoPlugin from 'draft-js-undo-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/Video/CustomAddVideoEditor/index.js
+++ b/stories/Video/CustomAddVideoEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createVideoPlugin from 'draft-js-video-plugin';
 import VideoAdd from './VideoAdd';

--- a/stories/Video/CustomVideoEditor/index.js
+++ b/stories/Video/CustomVideoEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState, convertFromRaw } from 'draft-js';
+import { EditorState, convertFromRaw } from '@wix/draft-js';
 import Editor, { composeDecorators } from 'draft-js-plugins-editor';
 
 import createAlignmentPlugin from 'draft-js-alignment-plugin';

--- a/stories/Video/SimpleVideoEditor/index.js
+++ b/stories/Video/SimpleVideoEditor/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { EditorState, convertFromRaw } from 'draft-js';
+import { EditorState, convertFromRaw } from '@wix/draft-js';
 import Editor from 'draft-js-plugins-editor';
 import createVideoPlugin from 'draft-js-video-plugin';
 import editorStyles from './editorStyles.css';

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import 'style-loader!css-loader!draft-js/dist/Draft.css'; // eslint-disable-line import/no-unresolved
+import 'style-loader!css-loader!@wix/draft-js/dist/Draft.css'; // eslint-disable-line import/no-unresolved
 
 import { storiesOf } from '@storybook/react';
 // import { action } from '@storybook/addon-actions';

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,6 +153,15 @@
   version "16.0.22"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.22.tgz#19ad106e124aceebd2b4d430a278d55413ee8759"
 
+"@wix/draft-js@^0.10.5":
+  version "0.10.647"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/draft-js/-/@wix/draft-js-0.10.647.tgz#15980a2d8996b27738e9d0fb624e170784c4fa73"
+  integrity sha1-FZgKLYmWsnc46dD7Yk4XB4TE+nM=
+  dependencies:
+    fbjs "^0.8.15"
+    immutable "~3.7.4"
+    object-assign "^4.1.0"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -2755,14 +2764,6 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-draft-js@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.5.tgz#bfa9beb018fe0533dbb08d6675c371a6b08fa742"
-  dependencies:
-    fbjs "^0.8.15"
-    immutable "~3.7.4"
-    object-assign "^4.1.0"
-
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -3410,9 +3411,10 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-find-with-regex@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/find-with-regex/-/find-with-regex-1.1.2.tgz#ce6fd971e25d73158b81849f30ccf867a580ef06"
+find-with-regex@^1.1.3:
+  version "1.1.3"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/find-with-regex/-/find-with-regex-1.1.3.tgz#d6c6f2debee898d36b6a77e05709b13dd5dc8a26"
+  integrity sha1-1sby3r7omNNranfgVwmxPdXciiY=
 
 flat-cache@^1.2.1:
   version "1.3.0"


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 9.852s
warning " > find-with-regex@1.1.3" has unmet peer dependency "draft-js@^0.10.5".
warning " > estraverse-fb@1.3.2" has unmet peer dependency "estraverse@*".
warning " > react-static-webpack-plugin@2.1.0" has unmet peer dependency "history@>= 4 < 5".



Output Log:
Migrating package "draft-js-plugins" in .


## Migration from non scope to @wix/scoped packages
> /tmp/0ebf7ff0c0484794965b6094688474c6

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
draft-js-alignment-plugin/package.json
draft-js-anchor-plugin/package.json
draft-js-buttons/package.json
draft-js-counter-plugin/package.json
draft-js-divider-plugin/package.json
draft-js-drag-n-drop-plugin/package.json
draft-js-drag-n-drop-upload-plugin/package.json
draft-js-emoji-plugin/package.json
draft-js-focus-plugin/package.json
draft-js-hashtag-plugin/package.json
draft-js-image-plugin/package.json
draft-js-inline-toolbar-plugin/package.json
draft-js-linkify-plugin/package.json
draft-js-mention-plugin/package.json
draft-js-plugins-editor/package.json
draft-js-plugins-utils/package.json
draft-js-resizeable-plugin/package.json
draft-js-side-toolbar-plugin/package.json
draft-js-static-toolbar-plugin/package.json
draft-js-sticker-plugin/package.json
draft-js-undo-plugin/package.json
draft-js-video-plugin/package.json
```

#### replace import/require in js/ts files
```
stories/index.js
draft-js-alignment-plugin/src/index.js
draft-js-drag-n-drop-plugin/src/handleDrop.js
draft-js-drag-n-drop-upload-plugin/src/handleDroppedFiles.js
draft-js-emoji-plugin/src/index.js
draft-js-focus-plugin/src/index.js
draft-js-plugins-utils/src/index.js
draft-js-resizeable-plugin/src/index.js
draft-js-anchor-plugin/src/utils/EditorUtils.js
draft-js-buttons/src/utils/createBlockStyleButton.js
draft-js-buttons/src/utils/createInlineStyleButton.js
draft-js-divider-plugin/src/modifiers/addDivider.js
draft-js-drag-n-drop-plugin/src/modifiers/addBlock.js
draft-js-drag-n-drop-plugin/src/modifiers/removeBlock.js
draft-js-drag-n-drop-upload-plugin/src/modifiers/modifyBlockData.js
draft-js-drag-n-drop-upload-plugin/src/modifiers/replaceBlock.js
draft-js-emoji-plugin/src/modifiers/addEmoji.js
draft-js-emoji-plugin/src/modifiers/attachImmutableEntitiesToEmojis.js
draft-js-focus-plugin/src/modifiers/insertNewLine.js
draft-js-focus-plugin/src/modifiers/removeBlock.js
draft-js-focus-plugin/src/modifiers/setSelection.js
draft-js-focus-plugin/src/modifiers/setSelectionToBlock.js
draft-js-image-plugin/src/modifiers/addImage.js
draft-js-mention-plugin/src/MentionSuggestions/index.js
draft-js-mention-plugin/src/modifiers/addMention.js
draft-js-plugins-editor/src/Editor/createCompositeDecorator.js
draft-js-plugins-editor/src/Editor/defaultKeyBindingPlugin.js
draft-js-plugins-editor/src/Editor/index.js
draft-js-plugins-editor/src/Editor/moveSelectionToEnd.js
draft-js-plugins-editor/src/utils/createEditorStateWithText.js
draft-js-sticker-plugin/src/modifiers/addSticker.js
draft-js-sticker-plugin/src/modifiers/cleanupEmptyStickers.js
draft-js-sticker-plugin/src/modifiers/removeSticker.js
draft-js-undo-plugin/src/RedoButton/index.js
draft-js-undo-plugin/src/UndoButton/index.js
draft-js-undo-plugin/src/__test__/index.js
stories/Alignment/SimpleAlignmentEditor/index.js
stories/Alignment/ThemedAlignmentEditor/index.js
stories/Divider/DividerWithSideToolbarEditor/index.js
stories/DragNDrop/CustomImageEditor/index.js
stories/Focus/SimpleFocusEditor/index.js
stories/Home/UnicornEditor/index.js
stories/Image/CustomImageEditor/index.js
stories/Image/SimpleImageEditor/index.js
stories/Linkify/CustomComponentLinkifyEditor/index.js
stories/Linkify/CustomLinkifyEditor/index.js
stories/Linkify/SimpleLinkifyEditor/index.js
stories/Mention/CustomComponentMentionEditor/index.js
stories/Mention/CustomMentionEditor/index.js
stories/Mention/MentionEditorWithCustomTrigger/index.js
stories/Mention/RemoteMentionEditor/index.js
stories/Mention/SimpleMentionEditor/index.js
stories/Resizeable/SimpleResizeableEditor/index.js
stories/Sticker/CustomStickerEditor/index.js
stories/Sticker/SimpleStickerEditor/index.js
stories/Undo/CustomUndoEditor/index.js
stories/Undo/SimpleUndoEditor/index.js
stories/Video/CustomAddVideoEditor/index.js
stories/Video/CustomVideoEditor/index.js
stories/Video/SimpleVideoEditor/index.js
draft-js-counter-plugin/src/CharCounter/__test__/index.js
draft-js-counter-plugin/src/CustomCounter/__test__/index.js
draft-js-counter-plugin/src/LineCounter/__test__/index.js
draft-js-counter-plugin/src/WordCounter/__test__/index.js
draft-js-emoji-plugin/src/components/EmojiSuggestions/index.js
draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
draft-js-mention-plugin/src/Mention/__test__/index.js
draft-js-plugins-editor/src/Editor/__test__/MultiDecorator.js
draft-js-plugins-editor/src/Editor/__test__/index.js
draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
draft-js-undo-plugin/src/RedoButton/__test__/index.js
draft-js-undo-plugin/src/UndoButton/__test__/index.js
draft-js-video-plugin/src/video/modifiers/addVideo.js
docs/client/components/pages/Alignment/SimpleAlignmentEditor/index.js
docs/client/components/pages/Alignment/ThemedAlignmentEditor/index.js
docs/client/components/pages/Divider/DividerWithSideToolbarEditor/index.js
docs/client/components/pages/DragNDrop/CustomImageEditor/index.js
docs/client/components/pages/Focus/SimpleFocusEditor/index.js
docs/client/components/pages/Home/UnicornEditor/index.js
docs/client/components/pages/Image/CustomImageEditor/index.js
docs/client/components/pages/Image/SimpleImageEditor/index.js
docs/client/components/pages/Linkify/CustomComponentLinkifyEditor/index.js
docs/client/components/pages/Linkify/CustomLinkifyEditor/index.js
docs/client/components/pages/Linkify/SimpleLinkifyEditor/index.js
docs/client/components/pages/Mention/CustomComponentMentionEditor/index.js
docs/client/components/pages/Mention/CustomMentionEditor/index.js
docs/client/components/pages/Mention/RemoteMentionEditor/index.js
docs/client/components/pages/Mention/SimpleMentionEditor/index.js
docs/client/components/pages/Playground/PlaygroundEditor/index.js
docs/client/components/pages/Resizeable/SimpleResizeableEditor/index.js
docs/client/components/pages/Sticker/CustomStickerEditor/index.js
docs/client/components/pages/Sticker/SimpleStickerEditor/index.js
docs/client/components/pages/Undo/CustomUndoEditor/index.js
docs/client/components/pages/Undo/SimpleUndoEditor/index.js
docs/client/components/pages/Video/CustomAddVideoVideoEditor/index.js
docs/client/components/pages/Video/CustomVideoEditor/index.js
docs/client/components/pages/Video/SimpleVideoEditor/index.js
```
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.1.2: The platform "linux" is incompatible with this module.
info "fsevents@1.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 35.93s.

