### PR TITLE
Nissix plugin scope-packages on draft-js-counter-plugin

### DIFF
--- a/draft-js-counter-plugin/package.json
+++ b/draft-js-counter-plugin/package.json
@@ -38,7 +38,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-counter-plugin/src/CharCounter/__test__/index.js
+++ b/draft-js-counter-plugin/src/CharCounter/__test__/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
-import { EditorState, ContentState } from 'draft-js';
+import { EditorState, ContentState } from '@wix/draft-js';
 import createCounterPlugin from '../../index';
 
 describe('CounterPlugin Character Counter', () => {

--- a/draft-js-counter-plugin/src/CustomCounter/__test__/index.js
+++ b/draft-js-counter-plugin/src/CustomCounter/__test__/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
-import { EditorState, ContentState } from 'draft-js';
+import { EditorState, ContentState } from '@wix/draft-js';
 import createCounterPlugin from '../../index';
 
 describe('CounterPlugin Line Counter', () => {

--- a/draft-js-counter-plugin/src/LineCounter/__test__/index.js
+++ b/draft-js-counter-plugin/src/LineCounter/__test__/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
-import { EditorState, ContentState } from 'draft-js';
+import { EditorState, ContentState } from '@wix/draft-js';
 import createCounterPlugin from '../../index';
 
 describe('CounterPlugin Line Counter', () => {

--- a/draft-js-counter-plugin/src/WordCounter/__test__/index.js
+++ b/draft-js-counter-plugin/src/WordCounter/__test__/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
-import { EditorState, ContentState } from 'draft-js';
+import { EditorState, ContentState } from '@wix/draft-js';
 import createCounterPlugin from '../../index';
 
 describe('CounterPlugin Word Counter', () => {


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 8.039s



Output Log:
Migrating package "draft-js-counter-plugin" in draft-js-counter-plugin


## Migration from non scope to @wix/scoped packages
> /tmp/51ca6198838b65f13cef92f939fe81f9/draft-js-counter-plugin

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/CharCounter/__test__/index.js
src/CustomCounter/__test__/index.js
src/LineCounter/__test__/index.js
src/WordCounter/__test__/index.js
```

