### PR TITLE
Nissix plugin scope-packages on draft-js-drag-n-drop-plugin

### DIFF
--- a/draft-js-drag-n-drop-plugin/package.json
+++ b/draft-js-drag-n-drop-plugin/package.json
@@ -36,7 +36,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-drag-n-drop-plugin/src/handleDrop.js
+++ b/draft-js-drag-n-drop-plugin/src/handleDrop.js
@@ -1,4 +1,4 @@
-import { EditorState, SelectionState } from 'draft-js';
+import { EditorState, SelectionState } from '@wix/draft-js';
 import addBlock from './modifiers/addBlock';
 import removeBlock from './modifiers/removeBlock';
 import { DRAFTJS_BLOCK_KEY } from './constants';

--- a/draft-js-drag-n-drop-plugin/src/modifiers/addBlock.js
+++ b/draft-js-drag-n-drop-plugin/src/modifiers/addBlock.js
@@ -5,7 +5,7 @@ import {
   BlockMapBuilder,
   ContentBlock,
   genKey
-} from 'draft-js';
+} from '@wix/draft-js';
 
 export default function (editorState, selection, type, data, entityType, text = ' ') {
   const currentContentState = editorState.getCurrentContent();

--- a/draft-js-drag-n-drop-plugin/src/modifiers/removeBlock.js
+++ b/draft-js-drag-n-drop-plugin/src/modifiers/removeBlock.js
@@ -1,4 +1,4 @@
-import { Modifier, SelectionState } from 'draft-js';
+import { Modifier, SelectionState } from '@wix/draft-js';
 
 export default function (contentState, blockKey) {
   const afterKey = contentState.getKeyAfter(blockKey);


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.998s



Output Log:
Migrating package "draft-js-drag-n-drop-plugin" in draft-js-drag-n-drop-plugin


## Migration from non scope to @wix/scoped packages
> /tmp/262a32cf7580391dae13a45e1fba6c8f/draft-js-drag-n-drop-plugin

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/handleDrop.js
src/modifiers/addBlock.js
src/modifiers/removeBlock.js
```

