### PR TITLE
Nissix plugin scope-packages on draft-js-drag-n-drop-upload-plugin

### DIFF
--- a/draft-js-drag-n-drop-upload-plugin/package.json
+++ b/draft-js-drag-n-drop-upload-plugin/package.json
@@ -36,7 +36,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-drag-n-drop-upload-plugin/src/handleDroppedFiles.js
+++ b/draft-js-drag-n-drop-upload-plugin/src/handleDroppedFiles.js
@@ -1,6 +1,6 @@
 // import replaceBlock from './modifiers/replaceBlock';
 // import modifyBlockData from './modifiers/modifyBlockData';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import { readFiles } from './utils/file';
 // import { getBlocksWhereEntityData } from './utils/block';
 

--- a/draft-js-drag-n-drop-upload-plugin/src/modifiers/modifyBlockData.js
+++ b/draft-js-drag-n-drop-upload-plugin/src/modifiers/modifyBlockData.js
@@ -1,4 +1,4 @@
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 
 export default function (editorState, key, data) {
   const currentContentState = editorState.getCurrentContent();

--- a/draft-js-drag-n-drop-upload-plugin/src/modifiers/replaceBlock.js
+++ b/draft-js-drag-n-drop-upload-plugin/src/modifiers/replaceBlock.js
@@ -1,4 +1,4 @@
-import { Modifier, EditorState, SelectionState } from 'draft-js';
+import { Modifier, EditorState, SelectionState } from '@wix/draft-js';
 
 export default function (editorState, blockKey, newType) {
   let content = editorState.getCurrentContent();


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 8.504s



Output Log:
Migrating package "draft-js-drag-n-drop-upload-plugin" in draft-js-drag-n-drop-upload-plugin


## Migration from non scope to @wix/scoped packages
> /tmp/d8c9c3a6567120af2d1718bc0eee05be/draft-js-drag-n-drop-upload-plugin

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/handleDroppedFiles.js
src/modifiers/modifyBlockData.js
src/modifiers/replaceBlock.js
```

