### PR TITLE
Nissix plugin scope-packages on draft-js-focus-plugin

### DIFF
--- a/draft-js-focus-plugin/package.json
+++ b/draft-js-focus-plugin/package.json
@@ -37,7 +37,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-focus-plugin/src/index.js
+++ b/draft-js-focus-plugin/src/index.js
@@ -1,4 +1,4 @@
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import insertNewLine from './modifiers/insertNewLine';
 import setSelection from './modifiers/setSelection';
 import setSelectionToBlock from './modifiers/setSelectionToBlock';

--- a/draft-js-focus-plugin/src/modifiers/insertNewLine.js
+++ b/draft-js-focus-plugin/src/modifiers/insertNewLine.js
@@ -4,7 +4,7 @@ import {
   EditorState,
   BlockMapBuilder,
   genKey as generateRandomKey,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 const insertBlockAfterSelection = (contentState, selectionState, newBlock) => {
   const targetKey = selectionState.getStartKey();

--- a/draft-js-focus-plugin/src/modifiers/removeBlock.js
+++ b/draft-js-focus-plugin/src/modifiers/removeBlock.js
@@ -1,4 +1,4 @@
-import { Modifier, EditorState, SelectionState } from 'draft-js';
+import { Modifier, EditorState, SelectionState } from '@wix/draft-js';
 
 /* NOT USED at the moment, but might be valuable if we want to fix atomic block behaviour */
 

--- a/draft-js-focus-plugin/src/modifiers/setSelection.js
+++ b/draft-js-focus-plugin/src/modifiers/setSelection.js
@@ -1,5 +1,5 @@
-import { SelectionState, EditorState } from 'draft-js';
-import DraftOffsetKey from 'draft-js/lib/DraftOffsetKey';
+import { SelectionState, EditorState } from '@wix/draft-js';
+import DraftOffsetKey from '@wix/draft-js/lib/DraftOffsetKey';
 
 // Set selection of editor to next/previous block
 export default (getEditorState, setEditorState, mode, event) => {

--- a/draft-js-focus-plugin/src/modifiers/setSelectionToBlock.js
+++ b/draft-js-focus-plugin/src/modifiers/setSelectionToBlock.js
@@ -1,5 +1,5 @@
-import { SelectionState, EditorState } from 'draft-js';
-import DraftOffsetKey from 'draft-js/lib/DraftOffsetKey';
+import { SelectionState, EditorState } from '@wix/draft-js';
+import DraftOffsetKey from '@wix/draft-js/lib/DraftOffsetKey';
 
 // Set selection of editor to next/previous block
 export default (getEditorState, setEditorState, newActiveBlock) => {


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 8.476s



Output Log:
Migrating package "draft-js-focus-plugin" in draft-js-focus-plugin


## Migration from non scope to @wix/scoped packages
> /tmp/1795db5aabeee5d57e4cd58cd2b41f5b/draft-js-focus-plugin

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/index.js
src/modifiers/insertNewLine.js
src/modifiers/removeBlock.js
src/modifiers/setSelection.js
src/modifiers/setSelectionToBlock.js
```

