### PR TITLE
Nissix plugin scope-packages on draft-js-inline-toolbar-plugin

### DIFF
--- a/draft-js-inline-toolbar-plugin/package.json
+++ b/draft-js-inline-toolbar-plugin/package.json
@@ -38,7 +38,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-inline-toolbar-plugin/src/components/Toolbar/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
-import { getVisibleSelectionRect } from 'draft-js';
+import { getVisibleSelectionRect } from '@wix/draft-js';
 
 export default class Toolbar extends React.Component {
 


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 10.092s



Output Log:
Migrating package "draft-js-inline-toolbar-plugin" in draft-js-inline-toolbar-plugin


## Migration from non scope to @wix/scoped packages
> /tmp/e29bd6ecb6f29f0df00a0a4773e47fe1/draft-js-inline-toolbar-plugin

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/components/Toolbar/index.js
```

