### PR TITLE
Nissix plugin scope-packages on draft-js-mention-plugin

### DIFF
--- a/draft-js-mention-plugin/package.json
+++ b/draft-js-mention-plugin/package.json
@@ -39,7 +39,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-mention-plugin/src/Mention/__test__/index.js
+++ b/draft-js-mention-plugin/src/Mention/__test__/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from 'enzyme';
 import { Map } from 'immutable';
-import { ContentState } from 'draft-js';
+import { ContentState } from '@wix/draft-js';
 import { expect } from 'chai';
 import Mention from '../index';
 

--- a/draft-js-mention-plugin/src/MentionSuggestions/index.js
+++ b/draft-js-mention-plugin/src/MentionSuggestions/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { genKey } from 'draft-js';
+import { genKey } from '@wix/draft-js';
 import escapeRegExp from 'lodash.escaperegexp';
 import Entry from './Entry';
 import addMention from '../modifiers/addMention';

--- a/draft-js-mention-plugin/src/modifiers/addMention.js
+++ b/draft-js-mention-plugin/src/modifiers/addMention.js
@@ -1,4 +1,4 @@
-import { Modifier, EditorState } from 'draft-js';
+import { Modifier, EditorState } from '@wix/draft-js';
 import getSearchText from '../utils/getSearchText';
 import getTypeByTrigger from '../utils/getTypeByTrigger';
 


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 10.915s



Output Log:
Migrating package "draft-js-mention-plugin" in draft-js-mention-plugin


## Migration from non scope to @wix/scoped packages
> /tmp/08cd05d5d5a6fcbaf88c8c35efc9da95/draft-js-mention-plugin

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/MentionSuggestions/index.js
src/modifiers/addMention.js
src/Mention/__test__/index.js
```

