### PR TITLE
Nissix plugin scope-packages on draft-js-plugins-editor

### DIFF
--- a/draft-js-plugins-editor/package.json
+++ b/draft-js-plugins-editor/package.json
@@ -35,7 +35,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-plugins-editor/src/Editor/__test__/MultiDecorator.js
+++ b/draft-js-plugins-editor/src/Editor/__test__/MultiDecorator.js
@@ -1,4 +1,4 @@
-import Draft from 'draft-js';
+import Draft from '@wix/draft-js';
 import { expect } from 'chai';
 import MultiDecorator from '../MultiDecorator';
 

--- a/draft-js-plugins-editor/src/Editor/__test__/index.js
+++ b/draft-js-plugins-editor/src/Editor/__test__/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { mount, shallow } from 'enzyme';
 import { expect } from 'chai';
-import { EditorState, DefaultDraftBlockRenderMap, Editor } from 'draft-js';
+import { EditorState, DefaultDraftBlockRenderMap, Editor } from '@wix/draft-js';
 import { Map } from 'immutable';
 import sinon from 'sinon';
 import PluginEditor, { createEditorStateWithText } from '../../index';

--- a/draft-js-plugins-editor/src/Editor/createCompositeDecorator.js
+++ b/draft-js-plugins-editor/src/Editor/createCompositeDecorator.js
@@ -3,7 +3,7 @@
  */
 
 import { List } from 'immutable';
-import { CompositeDecorator } from 'draft-js';
+import { CompositeDecorator } from '@wix/draft-js';
 import decorateComponentWithProps from 'decorate-component-with-props';
 
 export default (decorators, getEditorState, setEditorState) => {

--- a/draft-js-plugins-editor/src/Editor/defaultKeyBindingPlugin.js
+++ b/draft-js-plugins-editor/src/Editor/defaultKeyBindingPlugin.js
@@ -1,4 +1,4 @@
-import { getDefaultKeyBinding } from 'draft-js';
+import { getDefaultKeyBinding } from '@wix/draft-js';
 
 /**
  * Handle default key bindings.

--- a/draft-js-plugins-editor/src/Editor/index.js
+++ b/draft-js-plugins-editor/src/Editor/index.js
@@ -5,7 +5,7 @@ import {
   EditorState,
   Editor,
   DefaultDraftBlockRenderMap,
-} from 'draft-js';
+} from '@wix/draft-js';
 import { Map } from 'immutable';
 import proxies from './proxies';
 import moveSelectionToEnd from './moveSelectionToEnd';

--- a/draft-js-plugins-editor/src/Editor/moveSelectionToEnd.js
+++ b/draft-js-plugins-editor/src/Editor/moveSelectionToEnd.js
@@ -1,7 +1,7 @@
 import {
   EditorState,
   SelectionState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 /**
  * Returns a new EditorState where the Selection is at the end.

--- a/draft-js-plugins-editor/src/utils/createEditorStateWithText.js
+++ b/draft-js-plugins-editor/src/utils/createEditorStateWithText.js
@@ -5,7 +5,7 @@
 import {
   ContentState,
   EditorState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 export default (text) => EditorState.createWithContent(
   ContentState.createFromText(text)


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 9.361s



Output Log:
Migrating package "draft-js-plugins-editor" in draft-js-plugins-editor


## Migration from non scope to @wix/scoped packages
> /tmp/2fc030ee2b51f09e4d8101ee87c16a74/draft-js-plugins-editor

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/Editor/createCompositeDecorator.js
src/Editor/defaultKeyBindingPlugin.js
src/Editor/index.js
src/Editor/moveSelectionToEnd.js
src/utils/createEditorStateWithText.js
src/Editor/__test__/MultiDecorator.js
src/Editor/__test__/index.js
```

