### PR TITLE
Nissix plugin scope-packages on draft-js-plugins-utils

### DIFF
--- a/draft-js-plugins-utils/package.json
+++ b/draft-js-plugins-utils/package.json
@@ -30,6 +30,6 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "draft-js": "^0.10.1"
+    "@wix/draft-js": "^0.10.1"
   }
 }

--- a/draft-js-plugins-utils/src/index.js
+++ b/draft-js-plugins-utils/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 
-import { RichUtils, EditorState } from 'draft-js';
-import type DraftEntityInstance from 'draft-js/lib/DraftEntityInstance';
+import { RichUtils, EditorState } from '@wix/draft-js';
+import type DraftEntityInstance from '@wix/draft-js/lib/DraftEntityInstance';
 
 export default {
   createLinkAtSelection(editorState: EditorState, url: string): EditorState {


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 9.273s



Output Log:
Migrating package "draft-js-plugins-utils" in draft-js-plugins-utils


## Migration from non scope to @wix/scoped packages
> /tmp/fac732c0b0dc7c65ee6da39e522d40fc/draft-js-plugins-utils

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/index.js
```

