### PR TITLE
Nissix plugin scope-packages on draft-js-side-toolbar-plugin

### DIFF
--- a/draft-js-side-toolbar-plugin/package.json
+++ b/draft-js-side-toolbar-plugin/package.json
@@ -38,7 +38,7 @@
     "union-class-names": "^1.0.0"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
+++ b/draft-js-side-toolbar-plugin/src/components/Toolbar/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
-import DraftOffsetKey from 'draft-js/lib/DraftOffsetKey';
+import DraftOffsetKey from '@wix/draft-js/lib/DraftOffsetKey';
 
 export default class Toolbar extends React.Component {
 

--- a/draft-js-side-toolbar-plugin/yarn.lock
+++ b/draft-js-side-toolbar-plugin/yarn.lock
@@ -39,8 +39,9 @@ fbjs@^0.8.16:
     ua-parser-js "^0.7.9"
 
 find-with-regex@^1.1.3:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/find-with-regex/-/find-with-regex-1.0.2.tgz#d3b36286539f14c527e31f194159c6d251651a45"
+  version "1.1.3"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/find-with-regex/-/find-with-regex-1.1.3.tgz#d6c6f2debee898d36b6a77e05709b13dd5dc8a26"
+  integrity sha1-1sby3r7omNNranfgVwmxPdXciiY=
 
 iconv-lite@~0.4.13:
   version "0.4.21"


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 11.44s
warning Lockfile has incorrect entry for "find-with-regex@^1.1.3". Ignoring it.
warning " > decorate-component-with-props@1.1.0" has unmet peer dependency "react@^0.14.0 || ^15.0.0 || ^16.0.0".
warning " > draft-js-buttons@2.0.1" has unmet peer dependency "draft-js@^0.10.1".
warning " > draft-js-buttons@2.0.1" has unmet peer dependency "react@^15.5.0 || ^16.0.0-rc".
warning " > draft-js-buttons@2.0.1" has unmet peer dependency "react-dom@^15.5.0 || ^16.0.0-rc".
warning " > find-with-regex@1.1.3" has unmet peer dependency "draft-js@^0.10.5".



Output Log:
Migrating package "draft-js-side-toolbar-plugin" in draft-js-side-toolbar-plugin


## Migration from non scope to @wix/scoped packages
> /tmp/23c6d645d907df52cc8f6a3c86f2a5e3/draft-js-side-toolbar-plugin

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/components/Toolbar/index.js
```
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 0.91s.

