### PR TITLE
Nissix plugin scope-packages on draft-js-sticker-plugin

### DIFF
--- a/draft-js-sticker-plugin/package.json
+++ b/draft-js-sticker-plugin/package.json
@@ -38,7 +38,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-sticker-plugin/src/modifiers/addSticker.js
+++ b/draft-js-sticker-plugin/src/modifiers/addSticker.js
@@ -9,7 +9,7 @@ import {
   EditorState,
   genKey,
   Modifier,
-} from 'draft-js';
+} from '@wix/draft-js';
 import {
   List,
   Repeat

--- a/draft-js-sticker-plugin/src/modifiers/cleanupEmptyStickers.js
+++ b/draft-js-sticker-plugin/src/modifiers/cleanupEmptyStickers.js
@@ -6,7 +6,7 @@ import {
   EditorState,
   Modifier,
   SelectionState,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 const cleanupSticker = (editorState: Object, blockKey: String) => {
   const content = editorState.getCurrentContent();

--- a/draft-js-sticker-plugin/src/modifiers/removeSticker.js
+++ b/draft-js-sticker-plugin/src/modifiers/removeSticker.js
@@ -6,7 +6,7 @@ import {
   EditorState,
   Modifier,
   SelectionState
-} from 'draft-js';
+} from '@wix/draft-js';
 
 export default (editorState: Object, blockKey: String) => {
   let content = editorState.getCurrentContent();


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 10.099s



Output Log:
Migrating package "draft-js-sticker-plugin" in draft-js-sticker-plugin


## Migration from non scope to @wix/scoped packages
> /tmp/f2d84314868fc5e212e1bf13dd8bf18f/draft-js-sticker-plugin

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/modifiers/addSticker.js
src/modifiers/cleanupEmptyStickers.js
src/modifiers/removeSticker.js
```

