### PR TITLE
Nissix plugin scope-packages on draft-js-undo-plugin

### DIFF
--- a/draft-js-undo-plugin/package.json
+++ b/draft-js-undo-plugin/package.json
@@ -37,7 +37,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-undo-plugin/src/RedoButton/__test__/index.js
+++ b/draft-js-undo-plugin/src/RedoButton/__test__/index.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
-import { EditorState, Modifier } from 'draft-js';
+import { EditorState, Modifier } from '@wix/draft-js';
 import Redo from '../index';
 
 chai.use(sinonChai);

--- a/draft-js-undo-plugin/src/RedoButton/index.js
+++ b/draft-js-undo-plugin/src/RedoButton/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import unionClassNames from 'union-class-names';
 
 class RedoButton extends Component {

--- a/draft-js-undo-plugin/src/UndoButton/__test__/index.js
+++ b/draft-js-undo-plugin/src/UndoButton/__test__/index.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
-import { EditorState, Modifier } from 'draft-js';
+import { EditorState, Modifier } from '@wix/draft-js';
 import Undo from '../index';
 
 chai.use(sinonChai);

--- a/draft-js-undo-plugin/src/UndoButton/index.js
+++ b/draft-js-undo-plugin/src/UndoButton/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import unionClassNames from 'union-class-names';
 
 class UndoButton extends Component {

--- a/draft-js-undo-plugin/src/__test__/index.js
+++ b/draft-js-undo-plugin/src/__test__/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
-import { EditorState } from 'draft-js';
+import { EditorState } from '@wix/draft-js';
 import createUndoPlugin from '../index';
 
 describe('UndoPlugin Config', () => {


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 9.664s



Output Log:
Migrating package "draft-js-undo-plugin" in draft-js-undo-plugin


## Migration from non scope to @wix/scoped packages
> /tmp/f842b542bb369f7fee6851db5e81f1b9/draft-js-undo-plugin

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/RedoButton/index.js
src/UndoButton/index.js
src/__test__/index.js
src/RedoButton/__test__/index.js
src/UndoButton/__test__/index.js
```

