### PR TITLE
Nissix plugin scope-packages on draft-js-video-plugin

### DIFF
--- a/draft-js-video-plugin/package.json
+++ b/draft-js-video-plugin/package.json
@@ -35,7 +35,7 @@
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "draft-js": "^0.10.1",
+    "@wix/draft-js": "^0.10.1",
     "react": "^15.5.0 || ^16.0.0-rc",
     "react-dom": "^15.5.0 || ^16.0.0-rc"
   }

--- a/draft-js-video-plugin/src/video/modifiers/addVideo.js
+++ b/draft-js-video-plugin/src/video/modifiers/addVideo.js
@@ -1,7 +1,7 @@
 import {
   AtomicBlockUtils,
   RichUtils,
-} from 'draft-js';
+} from '@wix/draft-js';
 
 import * as types from '../constants';
 


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 11.456s



Output Log:
Migrating package "draft-js-video-plugin" in draft-js-video-plugin


## Migration from non scope to @wix/scoped packages
> /tmp/cc1c241136362efb320c47c9771505c6/draft-js-video-plugin

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/video/modifiers/addVideo.js
```

